### PR TITLE
nextcloud: bugfix for pm.max_children

### DIFF
--- a/nextcloud/values.yaml
+++ b/nextcloud/values.yaml
@@ -102,7 +102,7 @@ nextcloud:
   # PHP Configuration files
   # Will be injected in /usr/local/etc/php/conf.d for apache image and in /usr/local/etc/php-fpm.d when nginx.enabled: true
   phpConfigs:
-    nextcloud.custom.ini: |
+    zz-www.custom.ini: |
       [www]
       pm.max_children = 10
 


### PR DESCRIPTION
- Remove `--debug` which leaks secrets
- nextcloud: bump pm.max_children
- nextcloud: fix pool definition
- Move checkbox to bottom of the diff for UX
- fixup
