### PR TITLE
Remove required GITHUB_TOKEN

### DIFF
--- a/.github/workflows/helm-deploy-template.yml
+++ b/.github/workflows/helm-deploy-template.yml
@@ -27,8 +27,6 @@ on:
     secrets:
       GCLOUD_SERVICE_ACCOUNT_KEY:
         required: true
-      GITHUB_TOKEN:
-        required: true
       HELM_SECRET_VALUES:
         required: false
 

--- a/.github/workflows/kubectl-deploy-template.yml
+++ b/.github/workflows/kubectl-deploy-template.yml
@@ -20,8 +20,6 @@ on:
     secrets:
       GCLOUD_SERVICE_ACCOUNT_KEY:
         required: true
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   deploy:


### PR DESCRIPTION
Resolve:
> secret name `GITHUB_TOKEN` within `workflow_call` can not be used since it
> would collide with system reserved name